### PR TITLE
Various small improvements

### DIFF
--- a/eo3/utils/__init__.py
+++ b/eo3/utils/__init__.py
@@ -10,6 +10,7 @@ from .uris import (
     uri_to_local_path,
 )
 from .utils import (
+    Changeable,
     InvalidDocException,
     contains,
     default_utc,
@@ -44,4 +45,5 @@ __all__ = (
     "parse_time",
     "read_file",
     "flatten_dict",
+    "Changeable",
 )

--- a/eo3/utils/utils.py
+++ b/eo3/utils/utils.py
@@ -461,12 +461,12 @@ def read_file(p: Path):
 # TODO: general util
 # Type that can be checked for changes.
 # (MyPy approximation without recursive references)
-Changable = Union[str, int, None, Sequence[Any], Mapping[str, Any]]
+Changeable = Union[str, int, None, Sequence[Any], Mapping[str, Any]]
 # More accurate recursive definition:
-# Changable = Union[str, int, None, Sequence["Changable"], Mapping[str, "Changable"]]
+# Changeable = Union[str, int, None, Sequence["Changeable"], Mapping[str, "Changeable"]]
 
 
-def contains(v1: Changable, v2: Changable, case_sensitive: bool = False) -> bool:
+def contains(v1: Changeable, v2: Changeable, case_sensitive: bool = False) -> bool:
     """
     Check that v1 is a superset of v2.
 

--- a/requirements/deployment.txt
+++ b/requirements/deployment.txt
@@ -83,7 +83,7 @@ pyproj==3.4.0
     # via
     #   eo3 (setup.py)
     #   odc-geo
-pystac==1.7.3
+pystac==1.8.4
     # via eo3 (setup.py)
 python-dateutil==2.8.2
     # via

--- a/requirements/setup.txt
+++ b/requirements/setup.txt
@@ -82,7 +82,7 @@ pyproj==3.4.0
     # via
     #   eo3 (setup.py)
     #   odc-geo
-pystac==1.7.3
+pystac==1.8.4
     # via eo3 (setup.py)
 python-dateutil==2.8.2
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -178,7 +178,7 @@ pyproj==3.4.0
     #   eo3 (setup.py)
     #   morecantile
     #   odc-geo
-pystac==1.7.3
+pystac==1.8.4
     # via eo3 (setup.py)
 pytest==7.1.3
     # via

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         "click",
         "defusedxml",
         "h5py",
-        "jsonschema==4.18.0",  # We want a Draft7Validator, but 4.18.0 is the only version that works
+        "jsonschema>=4.18",
         "referencing",
         "numpy>=1.15.4",
         "odc-geo",
@@ -93,7 +93,7 @@ setup(
         "xarray",
         "toolz",
         "python-rapidjson",
-        "pystac>=1.7",
+        "pystac>=1.8.4",  # 1.8.4 fixes RefResolver issue
     ],
     tests_require=tests_require,
     extras_require=EXTRAS_REQUIRE,

--- a/tests/integration/data/tostac/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item_expected.json
+++ b/tests/integration/data/tostac/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item_expected.json
@@ -1137,7 +1137,7 @@
       -27.81689440711059
   ],
   "stac_extensions": [
-      "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+      "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
       "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
       "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -7,7 +7,7 @@ import toolz
 
 from eo3.fields import Range
 from eo3.model import DatasetMetadata
-from eo3.utils import default_utc
+from eo3.utils import InvalidDocException, default_utc
 from eo3.validate import InvalidDatasetError
 
 
@@ -58,6 +58,15 @@ def test_update_metadata_type(l1_ls8_folder_md_expected: Dict, metadata_type):
     )
     ds.metadata_type = new_metadata_type
     assert ds.instrument == "OLI_TIRS"
+
+    # we shouldn't be able to update the md type definition if it's invalid
+    bad_metadata_type = toolz.assoc_in(
+        metadata_type,
+        ["dataset", "creation_dt"],
+        ["properties", "invalid_offset"],
+    )
+    with pytest.raises(InvalidDocException):
+        ds.metadata_type = bad_metadata_type
 
 
 def test_additional_metadata_access(l1_ls8_folder_md_expected: Dict, metadata_type):
@@ -135,3 +144,13 @@ def test_warn_location_deprecated(
     ds = DatasetMetadata(l1_ls8_folder_md_expected)
     with pytest.warns(UserWarning, match="`location` is deprecated"):
         assert ds.locations == ["file:///path/to"]
+
+
+def test_embedded_lineage(l1_ls8_folder_md_expected: Dict):
+    """Error if dataset contains embedded lineage,
+    and that it's not lumped under 'incomplete_geometry'"""
+    l1_ls8_folder_md_expected["lineage"] = {
+        "source_datasets": {"ds": {"id": "abcd", "label": "00000"}}
+    }
+    with pytest.raises(InvalidDatasetError, match="invalid_lineage"):
+        DatasetMetadata(l1_ls8_folder_md_expected)

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -69,6 +69,20 @@ def test_update_metadata_type(l1_ls8_folder_md_expected: Dict, metadata_type):
         ds.metadata_type = bad_metadata_type
 
 
+def test_set_product_definition(
+    l1_ls8_folder_md_expected: Dict, metadata_type, eo3_product
+):
+    ds = DatasetMetadata(
+        raw_dict=l1_ls8_folder_md_expected,
+        mdt_definition=metadata_type,
+        product_definition=eo3_product,
+    )
+    new_product = toolz.assoc(eo3_product, "name", "other_product_name")
+    with pytest.warns(UserWarning, match="Cannot update"):
+        ds.product_definition = new_product
+    assert ds.product_definition == eo3_product
+
+
 def test_additional_metadata_access(l1_ls8_folder_md_expected: Dict, metadata_type):
     """Check that we are able to access metadata not defined in the metadata type"""
     ds = DatasetMetadata(

--- a/tests/integration/test_product_validate.py
+++ b/tests/integration/test_product_validate.py
@@ -152,6 +152,34 @@ def test_complains_about_impossible_nodata_vals(product: Dict):
     assert "unsuitable_nodata" in msgs.error_text()
 
 
+def test_rejects_invalid_measurements(product: Dict):
+    """Complain if measurements are invalid"""
+    # missing property (name)
+    product["measurements"] = [
+        dict(
+            dtype="uint8",
+            units="1",
+            nodata=0,
+        )
+    ]
+    msgs = MessageCatcher(validate_product(product))
+    assert "name" in msgs.error_text()
+
+    # invalid dtype
+    product["measurements"] = [
+        dict(name="red", dtype="random_type", units="1", nodata=-999)
+    ]
+    msgs = MessageCatcher(validate_product(product))
+    assert "random_type" in msgs.error_text()
+
+    # additional property
+    product["measurements"] = [
+        dict(name="red", dtype="uint8", units="1", nodata=0, asdf="asdf")
+    ]
+    msgs = MessageCatcher(validate_product(product))
+    assert "asdf" in msgs.error_text()
+
+
 def test_product_metadata_name(eo3_product):
     eo3_product["metadata"]["product"] = dict(name="spam")
     err_msgs = MessageCatcher(validate_product(eo3_product)).error_text()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,0 +1,268 @@
+import datetime
+import decimal
+from textwrap import dedent
+
+import pytest
+from ruamel.yaml import YAML
+
+from eo3.fields import (
+    Expression,
+    Range,
+    all_field_offsets,
+    get_search_fields,
+    get_system_fields,
+    parse_search_field,
+)
+
+METADATA_DOC = YAML(typ="safe").load(
+    """---
+name: test
+description: test all simple search field types
+dataset:
+  id: [id]
+  sources: [lineage, source_datasets]
+  label: [label]
+  creation_dt: [creation_dt]
+  search_fields:
+    x_default_type:
+       description: string type is assumed
+       offset: [some, path, x_default_type_path]
+
+    x_string:
+      type: string
+      description: field of type 'string'
+      offset: [x_string_path]
+
+    x_double:
+      type: double
+      description: field of type 'double'
+      offset: [x_double_path]
+
+    x_integer:
+      type: integer
+      description: field of type 'integer'
+      offset: [x_integer_path]
+
+    x_numeric:
+      type: numeric
+      description: field of type 'numeric'
+      offset: [x_numeric_path]
+
+    x_datetime:
+      type: datetime
+      description: field of type 'datetime'
+      offset: [x_datetime_path]
+"""
+)
+
+SAMPLE_DOC = YAML(typ="safe").load(
+    """---
+x_string_path: some_string
+x_double_path: 6.283185307179586
+x_integer_path: 4466778
+x_numeric_path: '100.33'
+x_datetime_path: 1999-04-15 12:33:55.001
+some:
+  path:
+    x_default_type_path: just_a_string
+"""
+)
+
+METADATA_DOC_RANGES = YAML(typ="safe").load(
+    """---
+name: test
+description: test all simple search field types
+dataset:
+  id: [id]
+  sources: [lineage, source_datasets]
+  label: [label]
+  creation_dt: [creation_dt]
+  search_fields:
+     t_range:
+       type: datetime-range
+       min_offset: [[t,a], [t,b]]
+       max_offset: [[t,a], [t,b]]
+
+     x_range:
+       type: double-range
+       min_offset: [[x,a], [x,b], [x,c], [x,d]]
+       max_offset: [[x,a], [x,b], [x,c], [x,d]]
+
+     float_range:
+       type: float-range
+       description: float-range is alias for numeric-range
+       min_offset: [[a]]
+       max_offset: [[b]]
+
+     ab:
+       type: integer-range
+       min_offset: [[a]]
+       max_offset: [[b]]
+"""
+)
+
+SAMPLE_DOC_RANGES = YAML(typ="safe").load(
+    """---
+t:
+  a: 1999-04-15
+  b: 1999-04-16
+x:
+  a: 1
+  b: 2
+  c: 3
+  d: 4
+"""
+)
+
+
+def test_get_dataset_simple_fields():
+    xx = get_search_fields(METADATA_DOC)
+    assert xx["x_default_type"].type_name == "string"
+
+    type_map = dict(
+        double=float,
+        integer=int,
+        string=str,
+        datetime=datetime.datetime,
+        numeric=decimal.Decimal,
+    )
+
+    for n, f in xx.items():
+        assert n == f.name
+        assert isinstance(f.description, str)
+
+        expected_type = type_map.get(f.type_name)
+        vv = f.extract(SAMPLE_DOC)
+        assert isinstance(vv, expected_type)
+
+        # missing data should return None
+        assert f.extract({}) is None
+
+
+def test_get_dataset_range_fields():
+    xx = get_search_fields(METADATA_DOC_RANGES)
+    v = xx["x_range"].extract(SAMPLE_DOC_RANGES)
+    assert v == Range(1, 4)
+
+    v = xx["t_range"].extract(SAMPLE_DOC_RANGES)
+    assert v.begin.strftime("%Y-%m-%d") == "1999-04-15"
+    assert v.end.strftime("%Y-%m-%d") == "1999-04-16"
+
+    # missing range should return None
+    assert xx["ab"].extract({}) is None
+
+    # partially missing Range
+    assert xx["ab"].extract(dict(a=3)) == Range(3, None)
+    assert xx["ab"].extract(dict(b=4)) == Range(None, 4)
+
+    # float-range conversion
+    assert xx["float_range"].type_name == "numeric-range"
+
+
+def test_get_system_fields():
+    xx = get_system_fields(METADATA_DOC)
+    assert "id" in xx
+    assert "sources" in xx
+    assert "label" in xx
+    assert "creation_dt" in xx
+    # shouldn't include anything from search_fields
+    assert len(xx) == 4
+
+
+def test_all_field_offsets():
+    xx = all_field_offsets(METADATA_DOC)
+    assert xx == {
+        "id": [["id"]],
+        "sources": [["lineage", "source_datasets"]],
+        "label": [["label"]],
+        "creation_dt": [["creation_dt"]],
+        "x_default_type": [["some", "path", "x_default_type_path"]],
+        "x_string": [["x_string_path"]],
+        "x_double": [["x_double_path"]],
+        "x_integer": [["x_integer_path"]],
+        "x_numeric": [["x_numeric_path"]],
+        "x_datetime": [["x_datetime_path"]],
+    }
+
+    xx = all_field_offsets(METADATA_DOC_RANGES)
+    assert xx == {
+        "id": [["id"]],
+        "sources": [["lineage", "source_datasets"]],
+        "label": [["label"]],
+        "creation_dt": [["creation_dt"]],
+        "t_range": [["t", "a"], ["t", "b"], ["t", "a"], ["t", "b"]],
+        "x_range": [
+            ["x", "a"],
+            ["x", "b"],
+            ["x", "c"],
+            ["x", "d"],
+            ["x", "a"],
+            ["x", "b"],
+            ["x", "c"],
+            ["x", "d"],
+        ],
+        "float_range": [["a"], ["b"]],
+        "ab": [["a"], ["b"]],
+    }
+
+
+def test_bad_field_definition():
+    def doc(s):
+        return YAML(typ="safe").load(dedent(s))
+
+    with pytest.raises(ValueError):
+        parse_search_field(
+            doc(
+                """
+        type: bad_type
+        offset: [a]
+        """
+            )
+        )
+
+    with pytest.raises(ValueError):
+        parse_search_field(
+            doc(
+                """
+        type: badtype-range
+        offset: [a]
+        """
+            )
+        )
+
+    with pytest.raises(ValueError):
+        parse_search_field(
+            doc(
+                """
+        type: double
+        description: missing offset
+        """
+            )
+        )
+
+    with pytest.raises(ValueError):
+        parse_search_field(
+            doc(
+                """
+        type: double-range
+        description: missing min_offset
+        max_offset: [[a]]
+        """
+            )
+        )
+
+    with pytest.raises(ValueError):
+        parse_search_field(
+            doc(
+                """
+        type: double-range
+        description: missing max_offset
+        min_offset: [[a]]
+        """
+            )
+        )
+
+
+def test_expression():
+    assert Expression() == Expression()
+    assert (Expression() == object()) is False


### PR DESCRIPTION
- Beef up tests, copy over some tests from core for fields and product validation
- Improve validation handling: don't have embedded lineage error lumped under 'incomplete_geometry', have errors/warnings for metadata type or product use 'InvalidDoc' instead of 'InvalidDataset'
- Add parameter to `from_path` classmethod to allow for metadata type definition path to be specified as well (optional)
- Rename 'Changable' to 'Changeable' for spelling's sake