### PR TITLE
CI: fix code coverage step

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,11 +26,11 @@ jobs:
 
     steps:
       - name: Checkout Git
-        uses: actions/checkout@v2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Determine Docker info from repo
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: ${{ env.IMAGE_NAME }}
 
@@ -39,17 +39,17 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: ${{ secrets.GADOCKERSVC_USERNAME }}
           password: ${{ secrets.GADOCKERSVC_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
@@ -31,11 +31,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,8 @@ on:
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -30,4 +31,5 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
+          use_oidc: true
           fail_ci_if_error: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
@@ -28,6 +28,6 @@ jobs:
           make test-root
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           fail_ci_if_error: false

--- a/eo3/eo3_core.py
+++ b/eo3/eo3_core.py
@@ -1,5 +1,5 @@
-""" Tools for working with EO3 metadata
-"""
+"""Tools for working with EO3 metadata"""
+
 import warnings
 from functools import reduce
 from typing import Any, Dict, Iterable, Optional, Tuple, Union

--- a/eo3/fields.py
+++ b/eo3/fields.py
@@ -190,7 +190,7 @@ def parse_search_field(doc, name=""):
 
 
 def get_search_fields(
-    metadata_definition: Mapping[str, Any]
+    metadata_definition: Mapping[str, Any],
 ) -> dict[str, SimpleField | RangeField]:
     """Construct search fields dictionary not tied to any specific db implementation."""
     fields = toolz.get_in(["dataset", "search_fields"], metadata_definition, {})
@@ -214,7 +214,7 @@ def parse_offset_field(name="", offset=[]):
 
 
 def get_system_fields(
-    metadata_definition: Mapping[str, Any]
+    metadata_definition: Mapping[str, Any],
 ) -> dict[str, SimpleField | RangeField]:
     """Construct system fields dictionary not tied to any specific db implementation."""
     fields = metadata_definition.get("dataset", {})
@@ -226,7 +226,7 @@ def get_system_fields(
 
 
 def get_all_fields(
-    metadata_definition: Mapping[str, Any]
+    metadata_definition: Mapping[str, Any],
 ) -> dict[str, SimpleField | RangeField]:
     """Construct dictionary of all fields"""
     search_fields = {
@@ -239,7 +239,7 @@ def get_all_fields(
 
 
 def all_field_offsets(
-    metadata_definition: Mapping[str, Any]
+    metadata_definition: Mapping[str, Any],
 ) -> dict[str, list[list[str]]]:
     """Get a mapping of all field names -> offset"""
     all_fields = get_all_fields(metadata_definition)

--- a/eo3/scripts/tostac.py
+++ b/eo3/scripts/tostac.py
@@ -1,6 +1,7 @@
 """
 Convert an EO3 metadata doc to a Stac Item.
 """
+
 import json
 from datetime import datetime
 from pathlib import Path

--- a/eo3/stac.py
+++ b/eo3/stac.py
@@ -1,6 +1,7 @@
 """
 Convert an EO3 metadata doc to a Stac Item. (BETA/Incomplete)
 """
+
 import datetime
 import math
 import mimetypes

--- a/eo3/utils/aws.py
+++ b/eo3/utils/aws.py
@@ -1,6 +1,7 @@
 """
 Helper methods for working with AWS
 """
+
 import os
 from typing import Any, Dict, Optional, Tuple, Union
 from urllib.parse import urlparse

--- a/eo3/validate.py
+++ b/eo3/validate.py
@@ -1,6 +1,7 @@
 """
 Validate ODC dataset documents
 """
+
 import warnings
 from textwrap import indent
 from typing import Any, Iterable, Mapping, Optional, Tuple

--- a/tests/test_eo3_core.py
+++ b/tests/test_eo3_core.py
@@ -1,6 +1,7 @@
 """
 Module
 """
+
 import pytest
 from affine import Affine
 from odc.geo.geom import CRS, polygon

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 Test utility functions
 (tests copied from datacube-core/tests/test_utils_docs.py and test_utils_generic.py)
 """
+
 from collections import OrderedDict
 from pathlib import Path
 from typing import Iterable, Tuple

--- a/tests/test_utils_uris.py
+++ b/tests/test_utils_uris.py
@@ -2,6 +2,7 @@
 Test utility uri functions
 (tests copied from datacube-core/tests/test_utils_other.py)
 """
+
 import os
 from pathlib import Path
 


### PR DESCRIPTION
The code coverage currently
fails because this repository
does not pass any token, so
generate an OIDC token and use
that.

Also throw in a commit that pins
the CI actions by hash.